### PR TITLE
表記誤記の修正およびNOTICEなしの旨追記

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,8 @@ https://opencv.org/license/
 - gspread:MIT
 
 https://github.com/burnash/gspread/blob/master/LICENSE.txt
-- oauth2client:Apatch License 2
+- oauth2client:Apache License 2.0
+※NOTICEファイルなしのため添付不要
 
 https://github.com/googleapis/oauth2client/blob/master/LICENSE
 - pandas: BSD 3-Clause "New" or "Revised" License

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ https://opencv.org/license/
 
 https://github.com/burnash/gspread/blob/master/LICENSE.txt
 - oauth2client:Apache License 2.0
-※NOTICEファイルなしのため添付不要
+※NOTICEファイルなしのためNOTICEファイルの添付不要
 
 https://github.com/googleapis/oauth2client/blob/master/LICENSE
 - pandas: BSD 3-Clause "New" or "Revised" License


### PR DESCRIPTION
@okuokuch 
Apache License 2.0の表記に誤記がありましたので修正しました。
また、NOTICEファイルなしのためNOTICE添付不要の旨追記しました。(#73 )